### PR TITLE
Allow being provided a list of services to bound to the apps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,14 @@ resource "cloudfoundry_app" "grafana" {
   routes {
     route = cloudfoundry_route.grafana.id
   }
+
+  dynamic "service_binding" {
+    for_each = var.grafana_service_bindings
+
+    content {
+      service_instance = service_binding.value.service_instance
+    }
+  }
 }
 
 resource "cloudfoundry_service_instance" "database" {

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,9 @@ variable "auto_assign_org_role" {
   description = "The default role to assign to auto signup users"
   default     = "Viewer"
 }
+
+variable "grafana_service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the grafana app"
+  default     = []
+}


### PR DESCRIPTION
I'm adding a variable to be possible to provide a list of services to be bound to the apps. Such a feature is needed for example to send the apps logs to the log bucket.